### PR TITLE
Update middleware.ts

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -10,7 +10,7 @@ const publicRoutes = [
     '/collections',
     '/parcours-groupe',
     '/collections/[id]',
-    '/events/id',
+    '/events/[id]',
     '/events',
     '/explorer',
     '/actualites',
@@ -77,6 +77,7 @@ export async function middleware(request: NextRequest) {
       data: { user },
     } = await supabase.auth.getUser()
       
+    /*
     const isPublicRoute = publicRoutes.some(route => {
       if (route.includes('[recovery_token]')) {
           const regex = new RegExp(`^${route.replace('[recovery_token]', '(.*)')}$`)
@@ -84,6 +85,12 @@ export async function middleware(request: NextRequest) {
       }
       return route === request.nextUrl.pathname
     })
+    */
+   const isPublicRoute = publicRoutes.some(route => {
+      const pattern = '^' + route.replace(/\[.*?\]/g, '[^/]+') + '$';
+      const regex = new RegExp(pattern);
+      return regex.test(request.nextUrl.pathname);
+    });
   
     if (!isPublicRoute && !user) {
         const url = request.nextUrl.clone()


### PR DESCRIPTION
Correction du middleware pour gérer les routes dynamiques dans publicRoutes

- Remplacement de l'égalité stricte par un matching par expression régulière pour les routes dynamiques (ex : /news/[id], /events/[id])
- Permet de reconnaître correctement toutes les routes publiques dynamiques afin d’éviter les redirections d’authentification non souhaitées
- Maintien du support des routes statiques et des routes avec tokens spécifiques